### PR TITLE
dockerise

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-
 Dockerfile
 .dockerignore
 .git/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+
+Dockerfile
+.dockerignore
+.git/
+.gitignore
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.12-alpine AS builder
+
+RUN apk add --no-cache --no-progress git
+
+WORKDIR /go/src/fastcgi-serve
+COPY . .
+
+RUN go get -d -v ./...
+RUN go install -v ./...
+
+
+#############
+# final image
+#############
+FROM alpine:3.10 AS final
+EXPOSE 8080
+ENTRYPOINT [ "fastcgi-serve" ]
+COPY --from=builder /go/bin /usr/local/bin


### PR DESCRIPTION
This will dockerise this project, image size is kept to a minimum:

```
❯ docker image ls | grep fastcgi-serve
fastcgi-serve                                                    latest              ba144d3c2beb        About a minute ago   13.3MB
```